### PR TITLE
Fix compilation: wrong include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Opus REQUIRED)
 find_package(OpusFile REQUIRED)
 
 include_directories(${KODI_INCLUDE_DIR}
+                    ${KODI_INCLUDE_DIR}/..
                     ${OGG_INCLUDE_DIRS}
                     ${OPUS_INCLUDE_DIRS}
                     ${OPUSFILE_INCLUDE_DIRS})


### PR DESCRIPTION
See commit description.

game.moonlight requires Opus, so I'm replacing its opus dependency with audiodecoder.opus.

This compilation error occured when I tried to compile audiodecoder.opus.

This probably isn't the best fix, but it fixed compilation for me, so it's a good place to start.
